### PR TITLE
readme: Config by flags on the executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ After completing the flow design in Node-RED, please ensure that you click the b
 
 ### 1. Build
 
+Using Rust 1.80 or later, run:
+
 ```bash
 cargo build -r
 ```
@@ -99,7 +101,8 @@ py.test
 
 ## Configuration
 
-Adjust various settings in the configuration file, such as port number, `flows.json` path, etc. Refer to [CONFIG.md](docs/CONFIG.md) for more information.
+Adjust various settings and configuration, please execute `edgelinkd` with flags.
+The flags available can be found when executing `edgelinkd --help`. 
 
 ## Project Status
 


### PR DESCRIPTION
The docs suggested there's a configuration file, which I was unable to locate. The way I've been able to configure the behaviour is through flags. This change records it in the README.